### PR TITLE
Use default order column name for default sort field.

### DIFF
--- a/src/Concerns/SortsIndexEntries.php
+++ b/src/Concerns/SortsIndexEntries.php
@@ -19,7 +19,7 @@ trait SortsIndexEntries
         $query->when(empty($request->get('orderBy')), function (Builder $q) {
             $q->getQuery()->orders = [];
 
-            return $q->orderBy(static::$defaultSortField);
+            return $q->orderBy(static::$defaultSortField ?? 'order_column');
         });
 
         return $query;


### PR DESCRIPTION
Added default order column name, so we don't need to define additional variable in nova resource if using default setup from spatie package 😉